### PR TITLE
Fixed import in example test to use gopkg.in.

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package lumberjack_test
 import (
 	"log"
 
-	"github.com/natefinch/lumberjack"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // To use lumberjack with the standard library's log package, just pass it into


### PR DESCRIPTION
The associated test case for `Example()` was failing as it imported the master branch (default Go behaviour). I've fixed this and it should restore the shiny "build passing" badge on the README as well.
