### PR TITLE
Adds gzip compression to backup log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ type Logger struct {
     // deleted.)
     MaxBackups int `json:"maxbackups" yaml:"maxbackups"`
 
+    // CompressBackups gzips the old log files specified by MaxAge and MaxBackups.
+    // The default is to not compress backups
+    CompressBackups bool `json:"compressbackups" yaml:"compressbackups"`
+
     // LocalTime determines if the time used for formatting the timestamps in
     // backup files is the computer's local time.  The default is to use UTC
     // time.

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -393,7 +393,6 @@ func compressLog(filename string) error {
 	if err != nil {
 		return err
 	}
-	defer rawfile.Close()
 
 	// Calculate the buffer size for rawfile
 	info, _ := rawfile.Stat()
@@ -414,6 +413,9 @@ func compressLog(filename string) error {
 	writer := gzip.NewWriter(&buf)
 	writer.Write(rawbytes)
 	writer.Close()
+
+	// Close the original file
+	rawfile.Close()
 
 	// Write the file with the same permissions as the original source log
 	err = ioutil.WriteFile(filename+compressFileExtension, buf.Bytes(), info.Mode())

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -166,11 +166,11 @@ func TestAutoRotate(t *testing.T) {
 	fileCount(dir, 2, t)
 }
 
-func TestAutoRotateCompressed(t *testing.T) {
+func TestCompressed(t *testing.T) {
 	currentTime = fakeTime
 	megabyte = 1
 
-	dir := makeTempDir("TestAutoRotateCompressed", t)
+	dir := makeTempDir("TestCompressed", t)
 	defer os.RemoveAll(dir)
 
 	filename := logFile(dir)
@@ -200,18 +200,17 @@ func TestAutoRotateCompressed(t *testing.T) {
 	// only the last write in it.
 	existsWithLen(filename, n, t)
 
+	l.compressLogs()
+
 	// the backup file will use the current fake time and have the old contents.
 	compressedFilename := backupFileCompressed(dir)
 	exists(compressedFilename, t)
 
 	// Verify that the compressed file contains the content
 	// that we compressed
-
-	// Open the compressed file
 	reader, err := os.Open(compressedFilename)
 	isNil(err, t)
 
-	// Wrap the reader with gzip
 	gzreader, err := gzip.NewReader(reader)
 	isNil(err, t)
 
@@ -527,7 +526,7 @@ func TestOldLogFiles(t *testing.T) {
 	isNil(err, t)
 
 	l := &Logger{Filename: filename}
-	files, err := l.oldLogFiles()
+	files, err := l.oldLogFiles(l.CompressBackups)
 	isNil(err, t)
 	equals(2, len(files), t)
 

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -163,6 +163,45 @@ func TestAutoRotate(t *testing.T) {
 	fileCount(dir, 2, t)
 }
 
+func TestAutoRotateCompressed(t *testing.T) {
+	currentTime = fakeTime
+	megabyte = 1
+
+	dir := makeTempDir("TestAutoRotateCompressed", t)
+	defer os.RemoveAll(dir)
+
+	filename := logFile(dir)
+	l := &Logger{
+		Filename:        filename,
+		MaxSize:         10,
+		CompressBackups: true,
+	}
+	defer l.Close()
+	b := []byte("boo!")
+	n, err := l.Write(b)
+	isNil(err, t)
+	equals(len(b), n, t)
+
+	existsWithLen(filename, n, t)
+	fileCount(dir, 1, t)
+
+	newFakeTime()
+
+	b2 := []byte("foooooo!")
+	n, err = l.Write(b2)
+	isNil(err, t)
+	equals(len(b2), n, t)
+
+	// the old logfile should be moved aside and the main logfile should have
+	// only the last write in it.
+	existsWithLen(filename, n, t)
+
+	// the backup file will use the current fake time and have the old contents.
+	exists(backupFileCompressed(dir), t)
+
+	fileCount(dir, 2, t)
+}
+
 func TestFirstWriteRotate(t *testing.T) {
 	currentTime = fakeTime
 	megabyte = 1
@@ -579,7 +618,8 @@ func TestJson(t *testing.T) {
 	"maxsize": 5,
 	"maxage": 10,
 	"maxbackups": 3,
-	"localtime": true
+	"localtime": true,
+	"compressbackups": true
 }`[1:])
 
 	l := Logger{}
@@ -590,6 +630,7 @@ func TestJson(t *testing.T) {
 	equals(10, l.MaxAge, t)
 	equals(3, l.MaxBackups, t)
 	equals(true, l.LocalTime, t)
+	equals(true, l.CompressBackups, t)
 }
 
 func TestYaml(t *testing.T) {
@@ -598,7 +639,8 @@ filename: foo
 maxsize: 5
 maxage: 10
 maxbackups: 3
-localtime: true`[1:])
+localtime: true
+compressbackups: true`[1:])
 
 	l := Logger{}
 	err := yaml.Unmarshal(data, &l)
@@ -608,6 +650,7 @@ localtime: true`[1:])
 	equals(10, l.MaxAge, t)
 	equals(3, l.MaxBackups, t)
 	equals(true, l.LocalTime, t)
+	equals(true, l.CompressBackups, t)
 }
 
 func TestToml(t *testing.T) {
@@ -616,7 +659,8 @@ filename = "foo"
 maxsize = 5
 maxage = 10
 maxbackups = 3
-localtime = true`[1:]
+localtime = true
+compressbackups = true`[1:]
 
 	l := Logger{}
 	md, err := toml.Decode(data, &l)
@@ -626,6 +670,7 @@ localtime = true`[1:]
 	equals(10, l.MaxAge, t)
 	equals(3, l.MaxBackups, t)
 	equals(true, l.LocalTime, t)
+	equals(true, l.CompressBackups, t)
 	equals(0, len(md.Undecoded()), t)
 }
 
@@ -654,6 +699,10 @@ func logFile(dir string) string {
 
 func backupFile(dir string) string {
 	return filepath.Join(dir, "foobar-"+fakeTime().UTC().Format(backupTimeFormat)+".log")
+}
+
+func backupFileCompressed(dir string) string {
+	return filepath.Join(dir, "foobar-"+fakeTime().UTC().Format(backupTimeFormat)+".log.gz")
 }
 
 func backupFileLocal(dir string) string {

--- a/rotate_test.go
+++ b/rotate_test.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/natefinch/lumberjack"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // Example of how to rotate in response to SIGHUP.


### PR DESCRIPTION
This PR adds gzip compression to backup log files via the CompressBackups config option. Tests added and passed. Please let me know if I missed anything.
Note: We're using this library in production (including gzipped backups) with max size as 100MB. Compression doesn't have any noticeable performance impact aside from saving a lot of drive space.  
