### PR TITLE
Update rotate_test.go to use v2 of project

### DIFF
--- a/rotate_test.go
+++ b/rotate_test.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/natefinch/lumberjack"
+	"github.com/natefinch/lumberjack.v2"
 )
 
 // Example of how to rotate in response to SIGHUP.

--- a/rotate_test.go
+++ b/rotate_test.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/natefinch/lumberjack.v2"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // Example of how to rotate in response to SIGHUP.


### PR DESCRIPTION
Hi there.  I thought it would be nice for the rotate example to use v2 of the package.
