### PR TITLE
Set umask in linux_test.go

### DIFF
--- a/linux_test.go
+++ b/linux_test.go
@@ -15,6 +15,7 @@ func TestMaintainMode(t *testing.T) {
 
 	filename := logFile(dir)
 
+	syscall.Umask(0002)
 	mode := os.FileMode(0770)
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR, mode)
 	isNil(err, t)


### PR DESCRIPTION
Hi there.  This particular test fails in my environment as my umask is set to 0022.  This patch sets the umask for the test to be something that will allow the test to pass.
