### PR TITLE
fix filemode in tests

### DIFF
--- a/linux_test.go
+++ b/linux_test.go
@@ -15,7 +15,7 @@ func TestMaintainMode(t *testing.T) {
 
 	filename := logFile(dir)
 
-	mode := os.FileMode(0770)
+	mode := os.FileMode(0600)
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR, mode)
 	isNil(err, t)
 	f.Close()

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -635,7 +635,7 @@ localtime = true`[1:]
 func makeTempDir(name string, t testing.TB) string {
 	dir := time.Now().Format(name + backupTimeFormat)
 	dir = filepath.Join(os.TempDir(), dir)
-	isNilUp(os.Mkdir(dir, 0777), t, 1)
+	isNilUp(os.Mkdir(dir, 0700), t, 1)
 	return dir
 }
 


### PR DESCRIPTION
This fixes #20 by using a more restrictive filemode during tests.
