### PR TITLE
Added ArchiveDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ type Logger struct {
     // os.TempDir() if empty.
     Filename string `json:"filename" yaml:"filename"`
 
+    // ArchiveDir is the directory where to write the rotated logs to.
+    // If not set it will default to the current directory of the logfile.
+    // Lumberjack will assume the archive directory already exists.
+    ArchiveDir string `json:"archivedir" yaml:"archivedir"`
+
     // MaxSize is the maximum size in megabytes of the log file before it gets
     // rotated. It defaults to 100 megabytes.
     MaxSize int `json:"maxsize" yaml:"maxsize"`
@@ -94,6 +99,9 @@ the log was rotated formatted with the time.Time format of
 example, if your Logger.Filename is `/var/log/foo/server.log`, a backup created
 at 6:30pm on Nov 11 2016 would use the filename
 `/var/log/foo/server-2016-11-04T18-30-00.000.log`
+
+If ArchiveDir is set it will backup the old logfiles to this directory.
+This directory is assumed to already exists.
 
 ### Cleaning Up Old Log Files
 Whenever a new logfile gets created, old log files may be deleted.  The most

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -82,7 +82,7 @@ type Logger struct {
 	// ArchiveDir is the directory where to write the rotated logs to.
 	// If not set it will default to the current directory of the logfile.
 	// Lumberjack will assume the archive directory already exists.
-	ArchiveDir string `json:"archivedir" yaml:"archivedir"`
+	ArchiveDir string `json:"archivedir,omitempty" yaml:"archivedir,omitempty"`
 
 	// MaxSize is the maximum size in megabytes of the log file before it gets
 	// rotated. It defaults to 100 megabytes.


### PR DESCRIPTION
Added a new property 'ArchiveDir'
Also added description to README.

Explanation and Reason:

### Real World Use Case
I have several golang application running; Lumberjack provides nice log rotation, however the log directory gets cluttered, because lumberjack writes to the same directory as the ```active``` log file.

So picture this:
A ```logs``` directory with the following ```active``` logs:
* server.log
* audit.log
* request.log

Currently Lumberjack will writes all old log files to the same directory as the active logfile.
With production systems where you are legally required to save logging for quite some time, this log directory gets quite crowded.

### END USE CASE

The provided pull request is very small in code and allows to set a alternate archive directory; but the impact of having the old rotated logs to a separate archive directory is in my opinion very valuable for production systems.

This pull request allows you to organize the location of the old logs.

Also this property was set as non-invasive with full backwards compliancy by setting it to 'omitempty'.

@natefinch Please consider this PR for production system daily operations.

Fully tested; see screenshots
![lumberjack1](https://cloud.githubusercontent.com/assets/6072255/24308419/2e43c58e-10c8-11e7-8baa-6e8b48fc2684.png)
![lumberjack2](https://cloud.githubusercontent.com/assets/6072255/24308436/3295e3c4-10c8-11e7-99b5-a851a26d57d8.png)

