### PR TITLE
Add capability to parse from TOML files for public Logger fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,28 +48,28 @@ type Logger struct {
     // Filename is the file to write logs to.  Backup log files will be retained
     // in the same directory.  It uses <processname>-lumberjack.log in
     // os.TempDir() if empty.
-    Filename string `json:"filename" yaml:"filename"`
+    Filename string `json:"filename" yaml:"filename" toml:"filename"`
 
     // MaxSize is the maximum size in megabytes of the log file before it gets
     // rotated. It defaults to 100 megabytes.
-    MaxSize int `json:"maxsize" yaml:"maxsize"`
+    MaxSize int `json:"maxsize" yaml:"maxsize" toml:"maxsize"`
 
     // MaxAge is the maximum number of days to retain old log files based on the
     // timestamp encoded in their filename.  Note that a day is defined as 24
     // hours and may not exactly correspond to calendar days due to daylight
     // savings, leap seconds, etc. The default is not to remove old log files
     // based on age.
-    MaxAge int `json:"maxage" yaml:"maxage"`
+    MaxAge int `json:"maxage" yaml:"maxage" toml:"maxage"`
 
     // MaxBackups is the maximum number of old log files to retain.  The default
     // is to retain all old log files (though MaxAge may still cause them to get
     // deleted.)
-    MaxBackups int `json:"maxbackups" yaml:"maxbackups"`
+    MaxBackups int `json:"maxbackups" yaml:"maxbackups" toml:"maxbackups"`
 
     // LocalTime determines if the time used for formatting the timestamps in
     // backup files is the computer's local time.  The default is to use UTC
     // time.
-    LocalTime bool `json:"localtime" yaml:"localtime"`
+    LocalTime bool `json:"localtime" yaml:"localtime" toml:"localtime"`
     // contains filtered or unexported fields
 }
 ```

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -80,32 +80,32 @@ type Logger struct {
 	// Filename is the file to write logs to.  Backup log files will be retained
 	// in the same directory.  It uses <processname>-lumberjack.log in
 	// os.TempDir() if empty.
-	Filename string `json:"filename" yaml:"filename"`
+	Filename string `json:"filename" yaml:"filename" toml:"filename"`
 
 	// MaxSize is the maximum size in megabytes of the log file before it gets
 	// rotated. It defaults to 100 megabytes.
-	MaxSize int `json:"maxsize" yaml:"maxsize"`
+	MaxSize int `json:"maxsize" yaml:"maxsize" toml:"maxsize"`
 
 	// MaxAge is the maximum number of days to retain old log files based on the
 	// timestamp encoded in their filename.  Note that a day is defined as 24
 	// hours and may not exactly correspond to calendar days due to daylight
 	// savings, leap seconds, etc. The default is not to remove old log files
 	// based on age.
-	MaxAge int `json:"maxage" yaml:"maxage"`
+	MaxAge int `json:"maxage" yaml:"maxage" toml:"maxage"`
 
 	// MaxBackups is the maximum number of old log files to retain.  The default
 	// is to retain all old log files (though MaxAge may still cause them to get
 	// deleted.)
-	MaxBackups int `json:"maxbackups" yaml:"maxbackups"`
+	MaxBackups int `json:"maxbackups" yaml:"maxbackups" toml:"maxbackups"`
 
 	// LocalTime determines if the time used for formatting the timestamps in
 	// backup files is the computer's local time.  The default is to use UTC
 	// time.
-	LocalTime bool `json:"localtime" yaml:"localtime"`
+	LocalTime bool `json:"localtime" yaml:"localtime" toml:"localtime"`
 
 	// Compress determines if the rotated log files should be compressed
 	// using gzip.
-	Compress bool `json:"compress" yaml:"compress"`
+	Compress bool `json:"compress" yaml:"compress" toml:"compress"`
 
 	size int64
 	file *os.File


### PR DESCRIPTION
In addition to YAML and JSON this simple PR adds support for [TOML](https://github.com/toml-lang/toml) fields.