### PR TITLE
Update docs, adding `Compress` setting details

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ log.SetOutput(&lumberjack.Logger{
     MaxSize:    500, // megabytes
     MaxBackups: 3,
     MaxAge:     28, //days
+    Compress:   true, // disabled by default
 })
 ```
 
@@ -70,6 +71,10 @@ type Logger struct {
     // backup files is the computer's local time.  The default is to use UTC
     // time.
     LocalTime bool `json:"localtime" yaml:"localtime"`
+
+    // Compress determines if the rotated log files should be compressed
+    // using gzip. The default is not to perform compression.
+    Compress bool `json:"compress" yaml:"compress"`
     // contains filtered or unexported fields
 }
 ```

--- a/example_test.go
+++ b/example_test.go
@@ -14,5 +14,6 @@ func Example() {
 		MaxSize:    500, // megabytes
 		MaxBackups: 3,
 		MaxAge:     28, // days
+		Compress:   true, // disabled by default
 	})
 }

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -104,7 +104,7 @@ type Logger struct {
 	LocalTime bool `json:"localtime" yaml:"localtime"`
 
 	// Compress determines if the rotated log files should be compressed
-	// using gzip.
+	// using gzip. The default is not to perform compression.
 	Compress bool `json:"compress" yaml:"compress"`
 
 	size int64


### PR DESCRIPTION
I only stumbled upon this feature by accident, but it has definitely been useful. I saw that it was recently added, so I filled in the gaps in the readme, example file, and godoc.

I did try at first to reuse the `godoc2md` generator, but more text gets changed and reordered than I cared to fight with. This PR is simply to increase discoverability of the feature I was glad to find out about.