### PR TITLE
Create new log file for test if it was removed

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -13,7 +13,7 @@ func Example() {
 		Filename:   "/var/log/myapp/foo.log",
 		MaxSize:    500, // megabytes
 		MaxBackups: 3,
-		MaxAge:     28, // days
+		MaxAge:     28,   // days
 		Compress:   true, // disabled by default
 	})
 }

--- a/linux_test.go
+++ b/linux_test.go
@@ -98,7 +98,7 @@ func TestCompressMaintainMode(t *testing.T) {
 	f.Close()
 
 	l := &Logger{
-		Compress: true,
+		Compress:   true,
 		Filename:   filename,
 		MaxBackups: 1,
 		MaxSize:    100, // megabytes
@@ -123,7 +123,7 @@ func TestCompressMaintainMode(t *testing.T) {
 	filename2 := backupFile(dir)
 	info, err := os.Stat(filename)
 	isNil(err, t)
-	info2, err := os.Stat(filename2+compressSuffix)
+	info2, err := os.Stat(filename2 + compressSuffix)
 	isNil(err, t)
 	equals(mode, info.Mode(), t)
 	equals(mode, info2.Mode(), t)

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -147,6 +147,18 @@ func (l *Logger) Write(p []byte) (n int, err error) {
 		if err = l.openExistingOrNew(len(p)); err != nil {
 			return 0, err
 		}
+	} else {
+		filename := l.filename()
+		_, err := os_Stat(filename)
+		if os.IsNotExist(err) {
+			err = l.openNew()
+			if err != nil {
+				return 0, fmt.Errorf("error opening new log file instead of deleted: %s", err)
+			}
+		}
+		if err != nil {
+			return 0, fmt.Errorf("error getting log file info: %s", err)
+		}
 	}
 
 	if l.size+writeLen > l.max() {

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -285,7 +285,7 @@ func TestMaxBackups(t *testing.T) {
 	// Create a log file that is/was being compressed - this should
 	// not be counted since both the compressed and the uncompressed
 	// log files still exist.
-	compLogFile := fourthFilename+compressSuffix
+	compLogFile := fourthFilename + compressSuffix
 	err = ioutil.WriteFile(compLogFile, []byte("compress"), 0644)
 	isNil(err, t)
 


### PR DESCRIPTION
User could delete file for log. I think that logger should create new file in this case to provide continuous logging. 