### PR TITLE
Fix test timing

### DIFF
--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -672,7 +672,7 @@ func TestCompressOnResume(t *testing.T) {
 
 	// we need to wait a little bit since the files get compressed on a different
 	// goroutine.
-	<-time.After(10 * time.Millisecond)
+	<-time.After(300 * time.Millisecond)
 
 	// The write should have started the compression - a compressed version of
 	// the log file should now exist and the original should have been removed.

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -285,7 +285,7 @@ func TestMaxBackups(t *testing.T) {
 	// Create a log file that is/was being compressed - this should
 	// not be counted since both the compressed and the uncompressed
 	// log files still exist.
-	compLogFile := fourthFilename+compressSuffix
+	compLogFile := fourthFilename + compressSuffix
 	err = ioutil.WriteFile(compLogFile, []byte("compress"), 0644)
 	isNil(err, t)
 
@@ -623,7 +623,7 @@ func TestCompressOnRotate(t *testing.T) {
 
 	// we need to wait a little bit since the files get compressed on a different
 	// goroutine.
-	<-time.After(10 * time.Millisecond)
+	<-time.After(300 * time.Millisecond)
 
 	// a compressed version of the log file should now exist and the original
 	// should have been removed.


### PR DESCRIPTION
tests were failing in CI because the compression and writing to disk in a secondary goroutine was taking longer than expected in tests.  The code is still accurate, it's just the test is too timing-specific.  This bandaids the problem by giving the tests a longer wait period, but we should really change the test so it polls rather than just waits. 