### PR TITLE
use 0755 to create new dir

### DIFF
--- a/lumberjack.go
+++ b/lumberjack.go
@@ -206,7 +206,7 @@ func (l *Logger) rotate() error {
 // openNew opens a new log file for writing, moving any old log file out of the
 // way.  This methods assumes the file has already been closed.
 func (l *Logger) openNew() error {
-	err := os.MkdirAll(l.dir(), 0744)
+	err := os.MkdirAll(l.dir(), 0755)
 	if err != nil {
 		return fmt.Errorf("can't make directories for new logfile: %s", err)
 	}


### PR DESCRIPTION
Use Case:

Application is running in production with user A, but when debugging I use user B to login on that machine, but 0744 prevent me from scanning files in the dir which is created by lumberjack. 0755 would be better