### PR TITLE
Add configs: DirPermMode, RotateFilePattern interface

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -15,6 +15,6 @@ func Example() {
 		MaxBackups:  3,
 		MaxAge:      28,   // days
 		Compress:    true, // disabled by default
-		DirPermMode: 0755, // 0644 by default
+		//DirPermMode: 0755, // 0644 by default
 	})
 }

--- a/example_test.go
+++ b/example_test.go
@@ -10,10 +10,11 @@ import (
 // the SetOutput function when your application starts.
 func Example() {
 	log.SetOutput(&lumberjack.Logger{
-		Filename:   "/var/log/myapp/foo.log",
-		MaxSize:    500, // megabytes
-		MaxBackups: 3,
-		MaxAge:     28, // days
-		Compress:   true, // disabled by default
+		Filename:    "/var/log/myapp/foo.log",
+		MaxSize:     500, // megabytes
+		MaxBackups:  3,
+		MaxAge:      28,   // days
+		Compress:    true, // disabled by default
+		DirPermMode: 0755, // 0644 by default
 	})
 }

--- a/linux_test.go
+++ b/linux_test.go
@@ -123,7 +123,7 @@ func TestCompressMaintainMode(t *testing.T) {
 	filename2 := backupFile(dir)
 	info, err := os.Stat(filename)
 	isNil(err, t)
-	info2, err := os.Stat(filename2+compressSuffix)
+	info2, err := os.Stat(filename2+CompressSuffix)
 	isNil(err, t)
 	equals(mode, info.Mode(), t)
 	equals(mode, info2.Mode(), t)
@@ -171,8 +171,8 @@ func TestCompressMaintainOwner(t *testing.T) {
 	// a compressed version of the log file should now exist with the correct
 	// owner.
 	filename2 := backupFile(dir)
-	equals(555, fakeFS.files[filename2+compressSuffix].uid, t)
-	equals(666, fakeFS.files[filename2+compressSuffix].gid, t)
+	equals(555, fakeFS.files[filename2+CompressSuffix].uid, t)
+	equals(666, fakeFS.files[filename2+CompressSuffix].gid, t)
 }
 
 type fakeFile struct {

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -285,7 +285,7 @@ func TestMaxBackups(t *testing.T) {
 	// Create a log file that is/was being compressed - this should
 	// not be counted since both the compressed and the uncompressed
 	// log files still exist.
-	compLogFile := fourthFilename + compressSuffix
+	compLogFile := fourthFilename + CompressSuffix
 	err = ioutil.WriteFile(compLogFile, []byte("compress"), 0644)
 	isNil(err, t)
 
@@ -296,7 +296,7 @@ func TestMaxBackups(t *testing.T) {
 	equals(len(b4), n, t)
 
 	existsWithContent(fourthFilename, b3, t)
-	existsWithContent(fourthFilename+compressSuffix, []byte("compress"), t)
+	existsWithContent(fourthFilename+CompressSuffix, []byte("compress"), t)
 
 	// we need to wait a little bit since the files get deleted on a different
 	// goroutine.
@@ -341,7 +341,7 @@ func TestCleanupExistingBackups(t *testing.T) {
 	newFakeTime()
 
 	backup = backupFile(dir)
-	err = ioutil.WriteFile(backup+compressSuffix, data, 0644)
+	err = ioutil.WriteFile(backup+CompressSuffix, data, 0644)
 	isNil(err, t)
 
 	newFakeTime()
@@ -475,35 +475,13 @@ func TestOldLogFiles(t *testing.T) {
 	isNil(err, t)
 
 	l := &Logger{Filename: filename}
-	files, err := l.oldLogFiles()
+	files, err := l.oldLogFiles(l.filename(), l.dir())
 	isNil(err, t)
 	equals(2, len(files), t)
 
 	// should be sorted by newest file first, which would be t2
-	equals(t2, files[0].timestamp, t)
-	equals(t1, files[1].timestamp, t)
-}
-
-func TestTimeFromName(t *testing.T) {
-	l := &Logger{Filename: "/var/log/myfoo/foo.log"}
-	prefix, ext := l.prefixAndExt()
-
-	tests := []struct {
-		filename string
-		want     time.Time
-		wantErr  bool
-	}{
-		{"foo-2014-05-04T14-44-33.555.log", time.Date(2014, 5, 4, 14, 44, 33, 555000000, time.UTC), false},
-		{"foo-2014-05-04T14-44-33.555", time.Time{}, true},
-		{"2014-05-04T14-44-33.555.log", time.Time{}, true},
-		{"foo.log", time.Time{}, true},
-	}
-
-	for _, test := range tests {
-		got, err := l.timeFromName(test.filename, prefix, ext)
-		equals(got, test.want, t)
-		equals(err != nil, test.wantErr, t)
-	}
+	equals(t2, files[0].Timestamp, t)
+	equals(t1, files[1].Timestamp, t)
 }
 
 func TestLocalTime(t *testing.T) {
@@ -633,7 +611,7 @@ func TestCompressOnRotate(t *testing.T) {
 	isNil(err, t)
 	err = gz.Close()
 	isNil(err, t)
-	existsWithContent(backupFile(dir)+compressSuffix, bc.Bytes(), t)
+	existsWithContent(backupFile(dir)+CompressSuffix, bc.Bytes(), t)
 	notExist(backupFile(dir), t)
 
 	fileCount(dir, 2, t)
@@ -659,7 +637,7 @@ func TestCompressOnResume(t *testing.T) {
 	b := []byte("foo!")
 	err := ioutil.WriteFile(filename2, b, 0644)
 	isNil(err, t)
-	err = ioutil.WriteFile(filename2+compressSuffix, []byte{}, 0644)
+	err = ioutil.WriteFile(filename2+CompressSuffix, []byte{}, 0644)
 	isNil(err, t)
 
 	newFakeTime()
@@ -682,7 +660,7 @@ func TestCompressOnResume(t *testing.T) {
 	isNil(err, t)
 	err = gz.Close()
 	isNil(err, t)
-	existsWithContent(filename2+compressSuffix, bc.Bytes(), t)
+	existsWithContent(filename2+CompressSuffix, bc.Bytes(), t)
 	notExist(filename2, t)
 
 	fileCount(dir, 2, t)

--- a/sanity.go
+++ b/sanity.go
@@ -1,0 +1,121 @@
+package lumberjack
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+	"os"
+	"io/ioutil"
+	"sort"
+	"strings"
+	"errors"
+)
+
+const (
+	CompressSuffix = ".gz"
+)
+
+var (
+	DEFAULT_ROTATE_FILE_PATTERN = &rotateFilePattern{}
+)
+
+type RotateFilePattern interface {
+	BackupName(name string, localTime bool) string
+	OldLogFiles(name, dir string) ([]*LogInfo, error)
+}
+
+type rotateFilePattern struct{}
+
+// backupName creates a new filename from the given name, inserting a timestamp
+// between the filename and the extension, using the local time if requested
+// (otherwise UTC).
+func (p *rotateFilePattern) BackupName(name string, local bool) string {
+	dir := filepath.Dir(name)
+	filename := filepath.Base(name)
+	ext := filepath.Ext(filename)
+	prefix := filename[:len(filename)-len(ext)]
+	t := currentTime()
+	if !local {
+		t = t.UTC()
+	}
+
+	timestamp := t.Format(backupTimeFormat)
+	return filepath.Join(dir, fmt.Sprintf("%s-%s%s", prefix, timestamp, ext))
+}
+
+// oldLogFiles returns the list of backup log files stored in the same
+// directory as the current log file, sorted by ModTime
+func (p *rotateFilePattern) OldLogFiles(name, dir string) ([]*LogInfo, error) {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("can't read log file directory: %s", err)
+	}
+	logFiles := []*LogInfo{}
+
+	prefix, ext := prefixAndExt(name)
+
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		if t, err := timeFromName(f.Name(), prefix, ext); err == nil {
+			logFiles = append(logFiles, &LogInfo{t, f})
+			continue
+		}
+		if t, err := timeFromName(f.Name(), prefix, ext+CompressSuffix); err == nil {
+			logFiles = append(logFiles, &LogInfo{t, f})
+			continue
+		}
+		// error parsing means that the suffix at the end was not generated
+		// by lumberjack, and therefore it's not a backup file.
+	}
+
+	sort.Sort(ByFormatTime(logFiles))
+
+	return logFiles, nil
+}
+
+// timeFromName extracts the formatted time from the filename by stripping off
+// the filename's prefix and extension. This prevents someone's filename from
+// confusing time.parse.
+func timeFromName(filename, prefix, ext string) (time.Time, error) {
+	if !strings.HasPrefix(filename, prefix) {
+		return time.Time{}, errors.New("mismatched prefix")
+	}
+	if !strings.HasSuffix(filename, ext) {
+		return time.Time{}, errors.New("mismatched extension")
+	}
+	ts := filename[len(prefix): len(filename)-len(ext)]
+	return time.Parse(backupTimeFormat, ts)
+}
+
+// prefixAndExt returns the filename part and extension part from the Logger's
+// filename.
+func prefixAndExt(name string) (prefix, ext string) {
+	filename := filepath.Base(name)
+	ext = filepath.Ext(filename)
+	prefix = filename[:len(filename)-len(ext)] + "-"
+	return prefix, ext
+}
+
+// logInfo is a convenience struct to return the filename and its embedded
+// timestamp.
+type LogInfo struct {
+	Timestamp time.Time
+	os.FileInfo
+}
+
+// byFormatTime sorts by newest time formatted in the name.
+type ByFormatTime []*LogInfo
+
+func (b ByFormatTime) Less(i, j int) bool {
+	return b[i].Timestamp.After(b[j].Timestamp)
+}
+
+func (b ByFormatTime) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}
+
+func (b ByFormatTime) Len() int {
+	return len(b)
+}


### PR DESCRIPTION
1. #59 add config: DirPermMode to overwrite defaultPermMode(0744)
2. add RotateFilePattern to overwrite rotate file name pattern
---

1. May expect create directories in perm: 0755
2. Would like to overwrite rotate file pattern like: access.log.20181224.175210
that's much more convenient than access-2018XXX.log