### PR TITLE
Post rotate hook

### DIFF
--- a/lumberjack.go
+++ b/lumberjack.go
@@ -109,8 +109,10 @@ type Logger struct {
 
 	// Hooks:
 	// AfterCompressFunc calls just after log file is rotated and has been compressed
+	// It runs with own goroutine, so it is not blocking
 	AfterCompressFunc func(filepath string)
 	// BeforeDeleteFunc is hook that calls before delete old log files and it can cancel deleting.
+	// Warning: it's blocking func so be carefull to run long-running tasks in this func
 	BeforeDeleteFunc func(filepath string) bool
 
 	size int64
@@ -381,7 +383,7 @@ func (l *Logger) millRunOnce() error {
 			err = errCompress
 		}
 		if errCompress == nil && l.AfterCompressFunc != nil {
-			l.AfterCompressFunc(fn+compressSuffix)
+			go l.AfterCompressFunc(fn+compressSuffix)
 		}
 	}
 


### PR DESCRIPTION
Hello.

I need to run a function after logFile has been rotated.
I don't see any way to do it in the code, so I implemented it myself.

There are two new callbacks:
AfterCompressFunc (filepath string)
BeforeDeleteFunc(filepath string) bool

First is async, second is blocking. BeforeDeleteFunc also can cancel file deleting by return FALSE, so it adds an ability to filter deleting files or do something before they will be deleted.

Both can be used to gracefully handle new log rotated, like:
```
lumberJackLogger.AfterCompressFunc = func(filepath string) {
        log.Println("AfterCompressFunc "+filepath)
	sendArchiveToServer(filepath)
}
```