### PR TITLE
Make default file permissions more restrictive

### DIFF
--- a/lumberjack.go
+++ b/lumberjack.go
@@ -212,7 +212,7 @@ func (l *Logger) openNew() error {
 	}
 
 	name := l.filename()
-	mode := os.FileMode(0644)
+	mode := os.FileMode(0600)
 	info, err := os_Stat(name)
 	if err == nil {
 		// Copy the mode off the old logfile.


### PR DESCRIPTION
This asures that the process can still read and write its own log file,
but that other users cannot. This is a fairly standard mode for log
files in linux.

This addresses #82 