### PR TITLE
add O_APPEND flag when open new log file

### DIFF
--- a/lumberjack.go
+++ b/lumberjack.go
@@ -232,7 +232,7 @@ func (l *Logger) openNew() error {
 	// we use truncate here because this should only get called when we've moved
 	// the file ourselves. if someone else creates the file in the meantime,
 	// just wipe out the contents.
-	f, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	f, err := os.OpenFile(name, os.O_CREATE|os.O_APPEND|os.O_WRONLY|os.O_TRUNC, mode)
 	if err != nil {
 		return fmt.Errorf("can't open new logfile: %s", err)
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix the problem of truncating file when opening a new log file.

Related:  https://superuser.com/questions/881777/what-happens-when-i-truncate-a-file-that-is-in-use

When I started a program with `lumberjack`, a new log file was created. Then I truncated the log file in another process, but I saw many characters like `^@` in the log file when I opened the file using Vim.

### What is changed and how it works?
Add the `O_APPEND` flag when opening a new log file.