### PR TITLE
Created Go module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ thusly:
 
     import "gopkg.in/natefinch/lumberjack.v2"
 
+Alternatively, the library may be used as a Go module:
+
+    import "github.com/natefinch/lumberjack/v2"
+
 The package name remains simply lumberjack, and the code resides at
 https://github.com/natefinch/lumberjack under the v2.0 branch.
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/natefinch/lumberjack/v2
+
+go 1.12
+
+require (
+	github.com/BurntSushi/toml v0.3.1
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Note that in the `go.mod` and `go.sum` files there are a few other modules listed, which are listed because Go v1.12 and above include the versions of dependencies of the test files as well, to ensure that the entire module can be rebuilt and retested exactly how it was on the developer's workstation.

While I am not a huge fan of listing and requiring test dependencies as if they were production dependencies, it is how the Go module system currently works.