### PR TITLE
Add MaxBytes to specify the log size in bytes and deprecate MaxSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Code:
 ```go
 log.SetOutput(&lumberjack.Logger{
     Filename:   "/var/log/myapp/foo.log",
-    MaxSize:    500, // megabytes
+    MaxBytes:    500 * 1024 * 1024, // 500 MiB
     MaxBackups: 3,
     MaxAge:     28, //days
     Compress:   true, // disabled by default
@@ -51,9 +51,9 @@ type Logger struct {
     // os.TempDir() if empty.
     Filename string `json:"filename" yaml:"filename"`
 
-    // MaxSize is the maximum size in megabytes of the log file before it gets
-    // rotated. It defaults to 100 megabytes.
-    MaxSize int `json:"maxsize" yaml:"maxsize"`
+    // MaxBytes is the maximum size in bytes of the log file before it gets
+    // rotated. It defaults to 104857600 (100 megabytes).
+    MaxBytes int64 `json:"maxbytes" yaml:"maxbytes"`
 
     // MaxAge is the maximum number of days to retain old log files based on the
     // timestamp encoded in their filename.  Note that a day is defined as 24
@@ -81,13 +81,13 @@ type Logger struct {
 Logger is an io.WriteCloser that writes to the specified filename.
 
 Logger opens or creates the logfile on first Write.  If the file exists and
-is less than MaxSize megabytes, lumberjack will open and append to that file.
-If the file exists and its size is >= MaxSize megabytes, the file is renamed
+is less than MaxBytes, lumberjack will open and append to that file.
+If the file exists and its size is >= MaxBytes, the file is renamed
 by putting the current time in a timestamp in the name immediately before the
 file's extension (or the end of the filename if there's no extension). A new
 log file is then created using original filename.
 
-Whenever a write would cause the current log file exceed MaxSize megabytes,
+Whenever a write would cause the current log file exceed MaxBytes,
 the current file is closed, renamed, and a new log file created with the
 original name. Thus, the filename you give Logger is always the "current" log
 file.
@@ -163,9 +163,9 @@ go func() {
 func (l *Logger) Write(p []byte) (n int, err error)
 ```
 Write implements io.Writer.  If a write would cause the log file to be larger
-than MaxSize, the file is closed, renamed to include a timestamp of the
+than MaxBytes, the file is closed, renamed to include a timestamp of the
 current time, and a new log file is created using the original log file name.
-If the length of the write is greater than MaxSize, an error is returned.
+If the length of the write is greater than MaxBytes, an error is returned.
 
 
 

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package lumberjack_test
 import (
 	"log"
 
-	"gopkg.in/natefinch/lumberjack.v2"
+	"github.com/natefinch/lumberjack"
 )
 
 // To use lumberjack with the standard library's log package, just pass it into

--- a/example_test.go
+++ b/example_test.go
@@ -11,9 +11,9 @@ import (
 func Example() {
 	log.SetOutput(&lumberjack.Logger{
 		Filename:   "/var/log/myapp/foo.log",
-		MaxSize:    500, // megabytes
+		MaxBytes:   500 * 1024 * 1024, // 500 MiB
 		MaxBackups: 3,
-		MaxAge:     28, // days
+		MaxAge:     28,   // days
 		Compress:   true, // disabled by default
 	})
 }

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -47,8 +47,8 @@ var _ io.WriteCloser = (*Logger)(nil)
 // Logger is an io.WriteCloser that writes to the specified filename.
 //
 // Logger opens or creates the logfile on first Write.  If the file exists and
-// is less than MaxSize megabytes, lumberjack will open and append to that file.
-// If the file exists and its size is >= MaxSize megabytes, the file is renamed
+// is less than MaxBytes, lumberjack will open and append to that file.
+// If the file exists and its size is >= MaxBytes, the file is renamed
 // by putting the current time in a timestamp in the name immediately before the
 // file's extension (or the end of the filename if there's no extension). A new
 // log file is then created using original filename.
@@ -82,6 +82,11 @@ type Logger struct {
 	// os.TempDir() if empty.
 	Filename string `json:"filename" yaml:"filename"`
 
+	// MaxBytes is the maximum size in bytes of the log file before it gets
+	// rotated. It defaults to 104857600 (100 megabytes).
+	MaxBytes int64 `json:"maxbytes" yaml:"maxbytes"`
+
+	// Deprecated: use MaxBytes instead.
 	// MaxSize is the maximum size in megabytes of the log file before it gets
 	// rotated. It defaults to 100 megabytes.
 	MaxSize int `json:"maxsize" yaml:"maxsize"`
@@ -129,9 +134,9 @@ var (
 )
 
 // Write implements io.Writer.  If a write would cause the log file to be larger
-// than MaxSize, the file is closed, renamed to include a timestamp of the
+// than MaxBytes, the file is closed, renamed to include a timestamp of the
 // current time, and a new log file is created using the original log file name.
-// If the length of the write is greater than MaxSize, an error is returned.
+// If the length of the write is greater than MaxBytes, an error is returned.
 func (l *Logger) Write(p []byte) (n int, err error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -259,8 +264,8 @@ func backupName(name string, local bool) string {
 }
 
 // openExistingOrNew opens the logfile if it exists and if the current write
-// would not put it over MaxSize.  If there is no such file or the write would
-// put it over the MaxSize, a new file is created.
+// would not put it over MaxBytes.  If there is no such file or the write would
+// put it over the MaxBytes, a new file is created.
 func (l *Logger) openExistingOrNew(writeLen int) error {
 	l.mill()
 
@@ -443,6 +448,9 @@ func (l *Logger) timeFromName(filename, prefix, ext string) (time.Time, error) {
 
 // max returns the maximum size in bytes of log files before rolling.
 func (l *Logger) max() int64 {
+	if l.MaxBytes != 0 {
+		return l.MaxBytes
+	}
 	if l.MaxSize == 0 {
 		return int64(defaultMaxSize * megabyte)
 	}


### PR DESCRIPTION
Close #37.