### PR TITLE
added RollingInterval, to rotate file every x sec.

### DIFF
--- a/lumberjack.go
+++ b/lumberjack.go
@@ -93,9 +93,9 @@ type Logger struct {
 	// based on age.
 	MaxAge int `json:"maxage" yaml:"maxage"`
 
-	//RollingInterval is the number of seconds before rotating to a new log file.
-	//the old log files will be deleted by the MaxAge & MaxBackups properties as usual.
-	//if the rolling interval is 0 the feature is off, default is 0.
+	// RollingInterval is the number of seconds before rotating to a new log file.
+	// the old log files will be deleted by the MaxAge & MaxBackups properties as usual.
+	// if the rolling interval is 0 the feature is off, default is 0.
 	RollingInterval int64 `json:"rollinginterval" yaml:"rollinginterval"`
 
 	// MaxBackups is the maximum number of old log files to retain.  The default
@@ -110,11 +110,11 @@ type Logger struct {
 
 	// Compress determines if the rotated log files should be compressed
 	// using gzip. The default is not to perform compression.
-	Compress    bool `json:"compress" yaml:"compress"`
-	createdTime int64
-	size        int64
-	file        *os.File
-	mu          sync.Mutex
+	Compress  bool `json:"compress" yaml:"compress"`
+	createdAt int64
+	size      int64
+	file      *os.File
+	mu        sync.Mutex
 
 	millCh    chan bool
 	startMill sync.Once
@@ -160,7 +160,7 @@ func (l *Logger) Write(p []byte) (n int, err error) {
 		}
 	}
 
-	if l.intervalExceeded() {
+	if l.exceedsRollingInterval() {
 		if err := l.rotate(); err != nil {
 			return 0, err
 		}
@@ -249,7 +249,7 @@ func (l *Logger) openNew() error {
 	}
 	l.file = f
 	l.size = 0
-	l.createdTime = time.Now().Unix()
+	l.createdAt = time.Now().Unix()
 	return nil
 }
 
@@ -461,9 +461,9 @@ func (l *Logger) max() int64 {
 	return int64(l.MaxSize) * int64(megabyte)
 }
 
-//isAfter checks if the log file creating time exceed the interval
-func (l *Logger) intervalExceeded() bool {
-	return l.RollingInterval > 0 && time.Now().Unix()-l.createdTime >= l.RollingInterval
+// exceedsRollingInterval checks if the log file age exceeds the rolling interval
+func (l *Logger) exceedsRollingInterval() bool {
+	return l.RollingInterval > 0 && time.Now().Unix()-l.createdAt >= l.RollingInterval
 }
 
 // dir returns the directory for the current filename.

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -93,6 +93,11 @@ type Logger struct {
 	// based on age.
 	MaxAge int `json:"maxage" yaml:"maxage"`
 
+	//RollingInterval is the number of seconds before rotating to a new log file.
+	//the old log files will be deleted by the MaxAge & MaxBackups properties as usual.
+	//if the rolling interval is 0 the feature is off, default is 0.
+	RollingInterval int64 `json:"rollinginterval" yaml:"rollinginterval"`
+
 	// MaxBackups is the maximum number of old log files to retain.  The default
 	// is to retain all old log files (though MaxAge may still cause them to get
 	// deleted.)
@@ -105,11 +110,11 @@ type Logger struct {
 
 	// Compress determines if the rotated log files should be compressed
 	// using gzip. The default is not to perform compression.
-	Compress bool `json:"compress" yaml:"compress"`
-
-	size int64
-	file *os.File
-	mu   sync.Mutex
+	Compress    bool `json:"compress" yaml:"compress"`
+	createdTime int64
+	size        int64
+	file        *os.File
+	mu          sync.Mutex
 
 	millCh    chan bool
 	startMill sync.Once
@@ -150,6 +155,12 @@ func (l *Logger) Write(p []byte) (n int, err error) {
 	}
 
 	if l.size+writeLen > l.max() {
+		if err := l.rotate(); err != nil {
+			return 0, err
+		}
+	}
+
+	if l.intervalExceeded() {
 		if err := l.rotate(); err != nil {
 			return 0, err
 		}
@@ -238,6 +249,7 @@ func (l *Logger) openNew() error {
 	}
 	l.file = f
 	l.size = 0
+	l.createdTime = time.Now().Unix()
 	return nil
 }
 
@@ -447,6 +459,11 @@ func (l *Logger) max() int64 {
 		return int64(defaultMaxSize * megabyte)
 	}
 	return int64(l.MaxSize) * int64(megabyte)
+}
+
+//isAfter checks if the log file creating time exceed the interval
+func (l *Logger) intervalExceeded() bool {
+	return l.RollingInterval > 0 && time.Now().Unix()-l.createdTime >= l.RollingInterval
 }
 
 // dir returns the directory for the current filename.

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -149,7 +149,7 @@ func TestRollingInterval(t *testing.T) {
 	equals(len(allBytes), bCount, t)
 	existsWithContent(filename, allBytes, t)
 	fileCount(dir, 1, t)
-	<-time.After(time.Millisecond * 2000)
+	l.createdAt = l.createdAt - 2
 	n, err := l.Write(b)
 	isNil(err, t)
 	equals(len(b), n, t)

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -136,7 +136,7 @@ func TestRollingInterval(t *testing.T) {
 	l := &Logger{
 		Filename:        filename,
 		MaxSize:         100,
-		RollingInterval: 1,
+		RollingInterval: 2,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -145,12 +145,11 @@ func TestRollingInterval(t *testing.T) {
 		n, err := l.Write(b)
 		isNil(err, t)
 		bCount += n
-		<-time.After(time.Millisecond * 100)
 	}
 	equals(len(allBytes), bCount, t)
 	existsWithContent(filename, allBytes, t)
 	fileCount(dir, 1, t)
-	<-time.After(time.Millisecond * 800)
+	<-time.After(time.Millisecond * 2000)
 	n, err := l.Write(b)
 	isNil(err, t)
 	equals(len(b), n, t)


### PR DESCRIPTION
added RollingInterval feature in order to generate new log file every single hour. 

RollingInterval is the number of seconds before rotating to a new log file.
the old log files will be deleted by the MaxAge & MaxBackups properties as usual. if the rolling interval is 0 the feature is off, default is 0.