### PR TITLE
Supports symbolic link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ _testmain.go
 
 *.exe
 *.test
+
+.idea

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Code:
 ```go
 log.SetOutput(&lumberjack.Logger{
     Filename:   "/var/log/myapp/foo.log",
+    Linkname:   "applog",
     MaxSize:    500, // megabytes
     MaxBackups: 3,
     MaxAge:     28, //days
@@ -50,6 +51,10 @@ type Logger struct {
     // in the same directory.  It uses <processname>-lumberjack.log in
     // os.TempDir() if empty.
     Filename string `json:"filename" yaml:"filename"`
+
+	// LinkName is a symbolic link name that links to the current filename
+	// being used. No symbolic link will be created if Linkname is empty.
+	LinkName string `json:"linkname" yaml:"linkname"`
 
     // MaxSize is the maximum size in megabytes of the log file before it gets
     // rotated. It defaults to 100 megabytes.

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -47,6 +47,26 @@ func TestNewFile(t *testing.T) {
 	fileCount(dir, 1, t)
 }
 
+func TestLinkname(t *testing.T) {
+	currentTime = fakeTime
+	linkName := "custom-linkname"
+
+	dir := makeTempDir("TestNewFile", t)
+	os.Mkdir(dir, 0755)
+	defer os.RemoveAll(dir)
+	l := &Logger{
+		Filename: logFile(dir),
+		LinkName: linkName,
+	}
+	//defer l.Close()
+	b := []byte("boo!")
+	n, err := l.Write(b)
+	isNil(err, t)
+	equals(len(b), n, t)
+	existsWithContent(filepath.Join(dir, linkName), b, t)
+	fileCount(dir, 2, t)
+}
+
 func TestOpenExisting(t *testing.T) {
 	currentTime = fakeTime
 	dir := makeTempDir("TestOpenExisting", t)


### PR DESCRIPTION
@natefinch Hi,

I think it will be better if lumberjack can support the symbolic link so that we needn't find out what logfile used in the current time.

At the most, we just use the command like `tail -f applog` to see what happens now.