### PR TITLE
Make default log file mode 0600

### DIFF
--- a/lumberjack.go
+++ b/lumberjack.go
@@ -277,7 +277,7 @@ func (l *Logger) openExistingOrNew(writeLen int) error {
 		return l.rotate()
 	}
 
-	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		// if we fail to open the old log file for some reason, just ignore
 		// it and open a new log file.


### PR DESCRIPTION
When a file is not pre-created, the default mode were 0644. This
could be very problematic for audit log files which require tighter
permissions.

This changes the default mode to be 0600 which is more
restrictive. Note that rotation of log files already uses this
mode by default. Also note that when files are pre-created, the mode the
file already had is respected.