### PR TITLE
Create the file when the file does not exist

### DIFF
--- a/lumberjack.go
+++ b/lumberjack.go
@@ -143,7 +143,9 @@ func (l *Logger) Write(p []byte) (n int, err error) {
 		)
 	}
 
-	if l.file == nil {
+	//create file when 1)init 2)file does not exist
+	_, err = osStat(l.filename())
+	if l.file == nil || os.IsNotExist(err) {
 		if err = l.openExistingOrNew(len(p)); err != nil {
 			return 0, err
 		}

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -74,6 +74,28 @@ func TestOpenExisting(t *testing.T) {
 	fileCount(dir, 1, t)
 }
 
+func TestOpenNotExisting(t *testing.T) {
+	currentTime = fakeTime
+	dir := makeTempDir("TestOpenNotExisting", t)
+	defer os.RemoveAll(dir)
+
+	filename := logFile(dir)
+	l := &Logger{
+		Filename: filename,
+	}
+	defer l.Close()
+	b := []byte("boo!")
+	n, err := l.Write(b)
+	isNil(err, t)
+	equals(len(b), n, t)
+
+	// make sure the file got appended
+	existsWithContent(filename, append(b), t)
+
+	// make sure no other files were created
+	fileCount(dir, 1, t)
+}
+
 func TestWriteTooLong(t *testing.T) {
 	currentTime = fakeTime
 	megabyte = 1


### PR DESCRIPTION
I realized Lumberjack in the `audit `module of `Kubernetes`. 

When the file is deleted, it needs to be recreated `without restarting the process` to ensure that the log is not lost.