### PR TITLE
Remove dependency on gopkg.in/yaml.v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
 module github.com/natefinch/lumberjack
 
-require (
-	github.com/BurntSushi/toml v0.3.1
-	gopkg.in/yaml.v2 v2.2.2
-)
+require github.com/BurntSushi/toml v0.3.1
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"gopkg.in/yaml.v2"
 )
 
 // !!!NOTE!!!
@@ -701,26 +700,6 @@ func TestJson(t *testing.T) {
 
 	l := Logger{}
 	err := json.Unmarshal(data, &l)
-	isNil(err, t)
-	equals("foo", l.Filename, t)
-	equals(5, l.MaxSize, t)
-	equals(10, l.MaxAge, t)
-	equals(3, l.MaxBackups, t)
-	equals(true, l.LocalTime, t)
-	equals(true, l.Compress, t)
-}
-
-func TestYaml(t *testing.T) {
-	data := []byte(`
-filename: foo
-maxsize: 5
-maxage: 10
-maxbackups: 3
-localtime: true
-compress: true`[1:])
-
-	l := Logger{}
-	err := yaml.Unmarshal(data, &l)
 	isNil(err, t)
 	equals("foo", l.Filename, t)
 	equals(5, l.MaxSize, t)


### PR DESCRIPTION
Ref: https://github.com/natefinch/lumberjack/issues/162#issuecomment-1159223786

@natefinch can we merge this and get a new tag cut `v2.2`? It'll help consumers of this library to update to a newer version and avoid the CVEs in `gopkg.in/yaml.v2`.