### PR TITLE
fix module declaration and remove toml dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
-module github.com/natefinch/lumberjack
-
-require github.com/BurntSushi/toml v0.3.1
+module gopkg.in/natefinch/lumberjack.v2
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
-github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -10,8 +10,6 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
-
-	"github.com/BurntSushi/toml"
 )
 
 // !!!NOTE!!!
@@ -707,27 +705,6 @@ func TestJson(t *testing.T) {
 	equals(3, l.MaxBackups, t)
 	equals(true, l.LocalTime, t)
 	equals(true, l.Compress, t)
-}
-
-func TestToml(t *testing.T) {
-	data := `
-filename = "foo"
-maxsize = 5
-maxage = 10
-maxbackups = 3
-localtime = true
-compress = true`[1:]
-
-	l := Logger{}
-	md, err := toml.Decode(data, &l)
-	isNil(err, t)
-	equals("foo", l.Filename, t)
-	equals(5, l.MaxSize, t)
-	equals(10, l.MaxAge, t)
-	equals(3, l.MaxBackups, t)
-	equals(true, l.LocalTime, t)
-	equals(true, l.Compress, t)
-	equals(0, len(md.Undecoded()), t)
 }
 
 // makeTempDir creates a file with a semi-unique name in the OS temp directory.


### PR DESCRIPTION
This fixes #177 and fixes #176 ... when the module declaration was added, it wasn't added with the gopkg.in format, which is what the official package name has been this whole time... so it broke people.  Sorry about that.

While I was in there, I removed the test for toml support... it added a dependency that was totally unnecessary for no real benefit. 