### PR TITLE
Implemented SyncWriter interface

### DIFF
--- a/lumberjack.go
+++ b/lumberjack.go
@@ -539,3 +539,15 @@ func (b byFormatTime) Swap(i, j int) {
 func (b byFormatTime) Len() int {
 	return len(b)
 }
+
+// Sync commits the current contents of the file to stable storage.
+// Typically, this means flushing the file system's in-memory copy
+// of recently written data to disk.
+func (l *Logger) Sync() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.file == nil {
+		return nil
+	}
+	return l.file.Sync()
+}


### PR DESCRIPTION
Implemented `SyncWriter` interface.

In some scenarios, we need to use the `SyncWriter` interface, such as integrating `lumberjack` and `go.uber.org/zap`.