### PR TITLE
Implement BeforeDeleteFunc

### DIFF
--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -374,6 +374,70 @@ func TestCleanupExistingBackups(t *testing.T) {
 	fileCount(dir, 2, t)
 }
 
+func TestCleanupExistingBackups_CallsCallback(t *testing.T) {
+	// test that if we start with more backup files than we're supposed to have
+	// in total, that extra ones get cleaned up when we rotate.
+
+	currentTime = fakeTime
+	megabyte = 1
+
+	dir := makeTempDir("TestCleanupExistingBackups", t)
+	defer os.RemoveAll(dir)
+
+	// make 3 backup files
+
+	data := []byte("data")
+	backup := backupFile(dir)
+	err := ioutil.WriteFile(backup, data, 0644)
+	isNil(err, t)
+
+	newFakeTime()
+
+	backup = backupFile(dir)
+	err = ioutil.WriteFile(backup+compressSuffix, data, 0644)
+	isNil(err, t)
+
+	newFakeTime()
+
+	backup = backupFile(dir)
+	err = ioutil.WriteFile(backup, data, 0644)
+	isNil(err, t)
+
+	// now create a primary log file with some data
+	filename := logFile(dir)
+	err = ioutil.WriteFile(filename, data, 0644)
+	isNil(err, t)
+
+	beforeDeleteFuncCallCount := 0
+
+	l := &Logger{
+		Filename:   filename,
+		MaxSize:    10,
+		MaxBackups: 1,
+		BeforeDeleteFunc: func(path string) {
+			beforeDeleteFuncCallCount++
+		},
+	}
+	defer l.Close()
+
+	newFakeTime()
+
+	b2 := []byte("foooooo!")
+	n, err := l.Write(b2)
+	isNil(err, t)
+	equals(len(b2), n, t)
+
+	// we need to wait a little bit since the files get deleted on a different
+	// goroutine.
+	<-time.After(time.Millisecond * 10)
+
+	// now we should only have 2 files left - the primary and one backup
+	fileCount(dir, 2, t)
+
+	// The BeforeDeleteFunc should have also been called exactly 3 times
+	equals(3, beforeDeleteFuncCallCount, t)
+}
+
 func TestMaxAge(t *testing.T) {
 	currentTime = fakeTime
 	megabyte = 1


### PR DESCRIPTION
Looking to use lumberjack for a personal project and the feature request in #195 would be a nice-to-have, so I implemented it myself.

I did this by adding a function pointer to the Logger struct and calling it just before deleting the file (after checking if it is nil, of course). I copy/pasted the `TestCleanupExistingBackups` test to `TestCleanupExistingBackups_CallsCallback` (so I know we're testing it with a known good test) and just increment a counter and validate that counter is the number we expect.