### PR TITLE
Fix documentation for MaxSize, rename conversion factor variable to match contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Code:
 ```go
 log.SetOutput(&lumberjack.Logger{
     Filename:   "/var/log/myapp/foo.log",
-    MaxSize:    500, // megabytes
+    MaxSize:    500, // mibibytes
     MaxBackups: 3,
     MaxAge:     28, //days
     Compress:   true, // disabled by default
@@ -51,8 +51,8 @@ type Logger struct {
     // os.TempDir() if empty.
     Filename string `json:"filename" yaml:"filename"`
 
-    // MaxSize is the maximum size in megabytes of the log file before it gets
-    // rotated. It defaults to 100 megabytes.
+    // MaxSize is the maximum size in mibibytes of the log file before it gets
+    // rotated. It defaults to 100 mibibytes.
     MaxSize int `json:"maxsize" yaml:"maxsize"`
 
     // MaxAge is the maximum number of days to retain old log files based on the
@@ -81,13 +81,13 @@ type Logger struct {
 Logger is an io.WriteCloser that writes to the specified filename.
 
 Logger opens or creates the logfile on first Write.  If the file exists and
-is less than MaxSize megabytes, lumberjack will open and append to that file.
-If the file exists and its size is >= MaxSize megabytes, the file is renamed
+is less than MaxSize mibibytes, lumberjack will open and append to that file.
+If the file exists and its size is >= MaxSize mibibytes, the file is renamed
 by putting the current time in a timestamp in the name immediately before the
 file's extension (or the end of the filename if there's no extension). A new
 log file is then created using original filename.
 
-Whenever a write would cause the current log file exceed MaxSize megabytes,
+Whenever a write would cause the current log file exceed MaxSize mibibytes,
 the current file is closed, renamed, and a new log file created with the
 original name. Thus, the filename you give Logger is always the "current" log
 file.

--- a/example_test.go
+++ b/example_test.go
@@ -9,7 +9,7 @@ import (
 func Example() {
 	log.SetOutput(&Logger{
 		Filename:   "/var/log/myapp/foo.log",
-		MaxSize:    500, // megabytes
+		MaxSize:    500, // mibibytes
 		MaxBackups: 3,
 		MaxAge:     28,   // days
 		Compress:   true, // disabled by default

--- a/linux_test.go
+++ b/linux_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package lumberjack
@@ -24,7 +25,7 @@ func TestMaintainMode(t *testing.T) {
 	l := &Logger{
 		Filename:   filename,
 		MaxBackups: 1,
-		MaxSize:    100, // megabytes
+		MaxSize:    100, // mibibytes
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -67,7 +68,7 @@ func TestMaintainOwner(t *testing.T) {
 	l := &Logger{
 		Filename:   filename,
 		MaxBackups: 1,
-		MaxSize:    100, // megabytes
+		MaxSize:    100, // mibibytes
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -101,7 +102,7 @@ func TestCompressMaintainMode(t *testing.T) {
 		Compress:   true,
 		Filename:   filename,
 		MaxBackups: 1,
-		MaxSize:    100, // megabytes
+		MaxSize:    100, // mibibytes
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -151,7 +152,7 @@ func TestCompressMaintainOwner(t *testing.T) {
 		Compress:   true,
 		Filename:   filename,
 		MaxBackups: 1,
-		MaxSize:    100, // megabytes
+		MaxSize:    100, // mibibytes
 	}
 	defer l.Close()
 	b := []byte("boo!")

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -3,7 +3,7 @@
 // Note that this is v2.0 of lumberjack, and should be imported using gopkg.in
 // thusly:
 //
-//   import "gopkg.in/natefinch/lumberjack.v2"
+//	import "gopkg.in/natefinch/lumberjack.v2"
 //
 // The package name remains simply lumberjack, and the code resides at
 // https://github.com/natefinch/lumberjack under the v2.0 branch.
@@ -47,13 +47,13 @@ var _ io.WriteCloser = (*Logger)(nil)
 // Logger is an io.WriteCloser that writes to the specified filename.
 //
 // Logger opens or creates the logfile on first Write.  If the file exists and
-// is less than MaxSize megabytes, lumberjack will open and append to that file.
-// If the file exists and its size is >= MaxSize megabytes, the file is renamed
+// is less than MaxSize mibibytes, lumberjack will open and append to that file.
+// If the file exists and its size is >= MaxSize mibibytes, the file is renamed
 // by putting the current time in a timestamp in the name immediately before the
 // file's extension (or the end of the filename if there's no extension). A new
 // log file is then created using original filename.
 //
-// Whenever a write would cause the current log file exceed MaxSize megabytes,
+// Whenever a write would cause the current log file exceed MaxSize mibibytes,
 // the current file is closed, renamed, and a new log file created with the
 // original name. Thus, the filename you give Logger is always the "current" log
 // file.
@@ -66,7 +66,7 @@ var _ io.WriteCloser = (*Logger)(nil)
 // `/var/log/foo/server.log`, a backup created at 6:30pm on Nov 11 2016 would
 // use the filename `/var/log/foo/server-2016-11-04T18-30-00.000.log`
 //
-// Cleaning Up Old Log Files
+// # Cleaning Up Old Log Files
 //
 // Whenever a new logfile gets created, old log files may be deleted.  The most
 // recent files according to the encoded timestamp will be retained, up to a
@@ -82,8 +82,8 @@ type Logger struct {
 	// os.TempDir() if empty.
 	Filename string `json:"filename" yaml:"filename"`
 
-	// MaxSize is the maximum size in megabytes of the log file before it gets
-	// rotated. It defaults to 100 megabytes.
+	// MaxSize is the maximum size in mibibytes of the log file before it gets
+	// rotated. It defaults to 100 mibibytes.
 	MaxSize int `json:"maxsize" yaml:"maxsize"`
 
 	// MaxAge is the maximum number of days to retain old log files based on the
@@ -122,10 +122,10 @@ var (
 	// os_Stat exists so it can be mocked out by tests.
 	osStat = os.Stat
 
-	// megabyte is the conversion factor between MaxSize and bytes.  It is a
-	// variable so tests can mock it out and not need to write megabytes of data
+	// mibibyte is the conversion factor between MaxSize and bytes.  It is a
+	// variable so tests can mock it out and not need to write mibibytes of data
 	// to disk.
-	megabyte = 1024 * 1024
+	mibibyte = 1024 * 1024
 )
 
 // Write implements io.Writer.  If a write would cause the log file to be larger
@@ -206,13 +206,13 @@ func (l *Logger) rotate() error {
 // openNew opens a new log file for writing, moving any old log file out of the
 // way.  This methods assumes the file has already been closed.
 func (l *Logger) openNew() error {
-	err := os.MkdirAll(l.dir(), 0755)
+	err := os.MkdirAll(l.dir(), 0o755)
 	if err != nil {
 		return fmt.Errorf("can't make directories for new logfile: %s", err)
 	}
 
 	name := l.filename()
-	mode := os.FileMode(0600)
+	mode := os.FileMode(0o600)
 	info, err := osStat(name)
 	if err == nil {
 		// Copy the mode off the old logfile.
@@ -277,7 +277,7 @@ func (l *Logger) openExistingOrNew(writeLen int) error {
 		return l.rotate()
 	}
 
-	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		// if we fail to open the old log file for some reason, just ignore
 		// it and open a new log file.
@@ -444,9 +444,9 @@ func (l *Logger) timeFromName(filename, prefix, ext string) (time.Time, error) {
 // max returns the maximum size in bytes of log files before rolling.
 func (l *Logger) max() int64 {
 	if l.MaxSize == 0 {
-		return int64(defaultMaxSize * megabyte)
+		return int64(defaultMaxSize * mibibyte)
 	}
-	return int64(l.MaxSize) * int64(megabyte)
+	return int64(l.MaxSize) * int64(mibibyte)
 }
 
 // dir returns the directory for the current filename.

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -73,7 +73,7 @@ func TestOpenExisting(t *testing.T) {
 
 func TestWriteTooLong(t *testing.T) {
 	currentTime = fakeTime
-	megabyte = 1
+	mibibyte = 1
 	dir := makeTempDir("TestWriteTooLong", t)
 	defer os.RemoveAll(dir)
 	l := &Logger{
@@ -126,7 +126,7 @@ func TestDefaultFilename(t *testing.T) {
 
 func TestAutoRotate(t *testing.T) {
 	currentTime = fakeTime
-	megabyte = 1
+	mibibyte = 1
 
 	dir := makeTempDir("TestAutoRotate", t)
 	defer os.RemoveAll(dir)
@@ -164,7 +164,7 @@ func TestAutoRotate(t *testing.T) {
 
 func TestFirstWriteRotate(t *testing.T) {
 	currentTime = fakeTime
-	megabyte = 1
+	mibibyte = 1
 	dir := makeTempDir("TestFirstWriteRotate", t)
 	defer os.RemoveAll(dir)
 
@@ -195,7 +195,7 @@ func TestFirstWriteRotate(t *testing.T) {
 
 func TestMaxBackups(t *testing.T) {
 	currentTime = fakeTime
-	megabyte = 1
+	mibibyte = 1
 	dir := makeTempDir("TestMaxBackups", t)
 	defer os.RemoveAll(dir)
 
@@ -323,7 +323,7 @@ func TestCleanupExistingBackups(t *testing.T) {
 	// in total, that extra ones get cleaned up when we rotate.
 
 	currentTime = fakeTime
-	megabyte = 1
+	mibibyte = 1
 
 	dir := makeTempDir("TestCleanupExistingBackups", t)
 	defer os.RemoveAll(dir)
@@ -376,7 +376,7 @@ func TestCleanupExistingBackups(t *testing.T) {
 
 func TestMaxAge(t *testing.T) {
 	currentTime = fakeTime
-	megabyte = 1
+	mibibyte = 1
 
 	dir := makeTempDir("TestMaxAge", t)
 	defer os.RemoveAll(dir)
@@ -443,7 +443,7 @@ func TestMaxAge(t *testing.T) {
 
 func TestOldLogFiles(t *testing.T) {
 	currentTime = fakeTime
-	megabyte = 1
+	mibibyte = 1
 
 	dir := makeTempDir("TestOldLogFiles", t)
 	defer os.RemoveAll(dir)
@@ -505,7 +505,7 @@ func TestTimeFromName(t *testing.T) {
 
 func TestLocalTime(t *testing.T) {
 	currentTime = fakeTime
-	megabyte = 1
+	mibibyte = 1
 
 	dir := makeTempDir("TestLocalTime", t)
 	defer os.RemoveAll(dir)
@@ -540,7 +540,7 @@ func TestRotate(t *testing.T) {
 	l := &Logger{
 		Filename:   filename,
 		MaxBackups: 1,
-		MaxSize:    100, // megabytes
+		MaxSize:    100, // mibibytes
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -589,7 +589,7 @@ func TestRotate(t *testing.T) {
 
 func TestCompressOnRotate(t *testing.T) {
 	currentTime = fakeTime
-	megabyte = 1
+	mibibyte = 1
 
 	dir := makeTempDir("TestCompressOnRotate", t)
 	defer os.RemoveAll(dir)
@@ -638,7 +638,7 @@ func TestCompressOnRotate(t *testing.T) {
 
 func TestCompressOnResume(t *testing.T) {
 	currentTime = fakeTime
-	megabyte = 1
+	mibibyte = 1
 
 	dir := makeTempDir("TestCompressOnResume", t)
 	defer os.RemoveAll(dir)


### PR DESCRIPTION
- Fixes documentation for `MaxSize` parameter.
- Fixes comments to match.
- Refactors the scaling factor variable so the name matches the contents.
- Cleans up some minor godoc formatting issues via `gofumpt`.