### PR TITLE
Ensure that the millRun goroutine terminates when Close called.

### DIFF
--- a/linux_test.go
+++ b/linux_test.go
@@ -98,13 +98,12 @@ func TestCompressMaintainMode(t *testing.T) {
 	isNil(err, t)
 	f.Close()
 
-	notify := make(chan struct{})
 	l := &Logger{
 		Compress:         true,
 		Filename:         filename,
 		MaxBackups:       1,
 		MaxSize:          100, // megabytes
-		notifyCompressed: notify,
+		notifyCompressed: make(chan struct{}),
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -117,7 +116,7 @@ func TestCompressMaintainMode(t *testing.T) {
 	err = l.Rotate()
 	isNil(err, t)
 
-	waitForNotify(notify, t)
+	waitForNotify(l.notifyCompressed, t)
 
 	// a compressed version of the log file should now exist with the correct
 	// mode.
@@ -148,13 +147,12 @@ func TestCompressMaintainOwner(t *testing.T) {
 	isNil(err, t)
 	f.Close()
 
-	notify := make(chan struct{})
 	l := &Logger{
 		Compress:         true,
 		Filename:         filename,
 		MaxBackups:       1,
 		MaxSize:          100, // megabytes
-		notifyCompressed: notify,
+		notifyCompressed: make(chan struct{}),
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -167,7 +165,7 @@ func TestCompressMaintainOwner(t *testing.T) {
 	err = l.Rotate()
 	isNil(err, t)
 
-	waitForNotify(notify, t)
+	waitForNotify(l.notifyCompressed, t)
 
 	// a compressed version of the log file should now exist with the correct
 	// owner.

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -281,6 +281,8 @@ func backupName(name string, local bool) string {
 // would not put it over MaxSize.  If there is no such file or the write would
 // put it over the MaxSize, a new file is created.
 func (l *Logger) openExistingOrNew(writeLen int) error {
+	l.mill()
+
 	filename := l.filename()
 	info, err := osStat(filename)
 	if os.IsNotExist(err) {

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -111,7 +111,18 @@ type Logger struct {
 	file *os.File
 	mu   sync.Mutex
 
+	wg     *sync.WaitGroup
 	millCh chan struct{}
+
+	// notifyCompressed is only set and used for tests. It is signalled when
+	// millRunOnce compresses some files. If no files are compressed,
+	// notifyCompressed is not signalled.
+	notifyCompressed chan struct{}
+
+	// notifyRemoved is only set and used for tests. It is signalled when the
+	// millRunOnce method removes some old log files. If no files are removed,
+	// notifyRemoved is not signalled.
+	notifyRemoved chan struct{}
 }
 
 var (
@@ -164,7 +175,16 @@ func (l *Logger) Write(p []byte) (n int, err error) {
 func (l *Logger) Close() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	return l.close()
+	if err := l.close(); err != nil {
+		return err
+	}
+	if l.millCh != nil {
+		close(l.millCh)
+		l.wg.Wait()
+		l.millCh = nil
+		l.wg = nil
+	}
+	return nil
 }
 
 // close closes the file if it is open.
@@ -174,10 +194,6 @@ func (l *Logger) close() error {
 	}
 	err := l.file.Close()
 	l.file = nil
-	if l.millCh != nil {
-		close(l.millCh)
-		l.millCh = nil
-	}
 	return err
 }
 
@@ -265,8 +281,6 @@ func backupName(name string, local bool) string {
 // would not put it over MaxSize.  If there is no such file or the write would
 // put it over the MaxSize, a new file is created.
 func (l *Logger) openExistingOrNew(writeLen int) error {
-	l.mill()
-
 	filename := l.filename()
 	info, err := osStat(filename)
 	if os.IsNotExist(err) {
@@ -359,20 +373,30 @@ func (l *Logger) millRunOnce() error {
 		}
 	}
 
+	filesRemoved := false
 	for _, f := range remove {
 		errRemove := os.Remove(filepath.Join(l.dir(), f.Name()))
 		if err == nil && errRemove != nil {
 			err = errRemove
 		}
+		filesRemoved = true
 	}
+	if filesRemoved && l.notifyRemoved != nil {
+		l.notifyRemoved <- struct{}{}
+	}
+
+	filesCompressed := false
 	for _, f := range compress {
 		fn := filepath.Join(l.dir(), f.Name())
 		errCompress := compressLogFile(fn, fn+compressSuffix)
 		if err == nil && errCompress != nil {
 			err = errCompress
 		}
+		filesCompressed = true
 	}
-
+	if filesCompressed && l.notifyCompressed != nil {
+		l.notifyCompressed <- struct{}{}
+	}
 	return err
 }
 
@@ -391,7 +415,12 @@ func (l *Logger) mill() {
 	// It is safe to check the millCh here as we are inside the mutex lock.
 	if l.millCh == nil {
 		l.millCh = make(chan struct{}, 1)
-		go l.millRun(l.millCh)
+		l.wg = &sync.WaitGroup{}
+		l.wg.Add(1)
+		go func() {
+			l.millRun(l.millCh)
+			l.wg.Done()
+		}()
 	}
 	select {
 	case l.millCh <- struct{}{}:

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -366,7 +366,11 @@ func TestCleanupExistingBackups(t *testing.T) {
 
 	newFakeTime()
 
-	b2 := []byte("foooooo!")
+	// Don't write enough to trigger a rotate or there is
+	// a race between whether or not there is one notification
+	// or two depending on how far through the millRunOnce method
+	// gets before the Write method calls rotate.
+	b2 := []byte("foo")
 	n, err := l.Write(b2)
 	isNil(err, t)
 	equals(len(b2), n, t)
@@ -627,6 +631,55 @@ func TestCompressOnRotate(t *testing.T) {
 	isNil(err, t)
 	existsWithContent(backupFile(dir)+compressSuffix, bc.Bytes(), t)
 	notExist(backupFile(dir), t)
+
+	fileCount(dir, 2, t)
+}
+
+func TestCompressOnResume(t *testing.T) {
+	currentTime = fakeTime
+	megabyte = 1
+
+	dir := makeTempDir("TestCompressOnResume", t)
+	defer os.RemoveAll(dir)
+
+	notify := make(chan struct{})
+	filename := logFile(dir)
+	l := &Logger{
+		Compress:         true,
+		Filename:         filename,
+		MaxSize:          10,
+		notifyCompressed: notify,
+	}
+	defer l.Close()
+
+	// Create a backup file and empty "compressed" file.
+	filename2 := backupFile(dir)
+	b := []byte("foo!")
+	err := ioutil.WriteFile(filename2, b, 0644)
+	isNil(err, t)
+	err = ioutil.WriteFile(filename2+compressSuffix, []byte{}, 0644)
+	isNil(err, t)
+
+	newFakeTime()
+
+	b2 := []byte("boo!")
+	n, err := l.Write(b2)
+	isNil(err, t)
+	equals(len(b2), n, t)
+	existsWithContent(filename, b2, t)
+
+	waitForNotify(notify, t)
+
+	// The write should have started the compression - a compressed version of
+	// the log file should now exist and the original should have been removed.
+	bc := new(bytes.Buffer)
+	gz := gzip.NewWriter(bc)
+	_, err = gz.Write(b)
+	isNil(err, t)
+	err = gz.Close()
+	isNil(err, t)
+	existsWithContent(filename2+compressSuffix, bc.Bytes(), t)
+	notExist(filename2, t)
 
 	fileCount(dir, 2, t)
 }

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -21,9 +22,14 @@ import (
 // Since all the tests uses the time to determine filenames etc, we need to
 // control the wall clock as much as possible, which means having a wall clock
 // that doesn't change unless we want it to.
-var fakeCurrentTime = time.Now()
+var (
+	fakeCurrentTime = time.Now()
+	fakeTimeMu      sync.Mutex
+)
 
 func fakeTime() time.Time {
+	fakeTimeMu.Lock()
+	defer fakeTimeMu.Unlock()
 	return fakeCurrentTime
 }
 
@@ -199,11 +205,13 @@ func TestMaxBackups(t *testing.T) {
 	dir := makeTempDir("TestMaxBackups", t)
 	defer os.RemoveAll(dir)
 
+	notify := make(chan struct{})
 	filename := logFile(dir)
 	l := &Logger{
-		Filename:   filename,
-		MaxSize:    10,
-		MaxBackups: 1,
+		Filename:      filename,
+		MaxSize:       10,
+		MaxBackups:    1,
+		notifyRemoved: notify,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -245,9 +253,7 @@ func TestMaxBackups(t *testing.T) {
 
 	existsWithContent(filename, b3, t)
 
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(time.Millisecond * 10)
+	waitForNotify(notify, t)
 
 	// should only have two files in the dir still
 	fileCount(dir, 2, t)
@@ -295,9 +301,7 @@ func TestMaxBackups(t *testing.T) {
 	existsWithContent(fourthFilename, b3, t)
 	existsWithContent(fourthFilename+compressSuffix, []byte("compress"), t)
 
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(time.Millisecond * 10)
+	waitForNotify(notify, t)
 
 	// We should have four things in the directory now - the 2 log files, the
 	// not log file, and the directory
@@ -351,11 +355,12 @@ func TestCleanupExistingBackups(t *testing.T) {
 	filename := logFile(dir)
 	err = ioutil.WriteFile(filename, data, 0644)
 	isNil(err, t)
-
+	notify := make(chan struct{})
 	l := &Logger{
-		Filename:   filename,
-		MaxSize:    10,
-		MaxBackups: 1,
+		Filename:      filename,
+		MaxSize:       10,
+		MaxBackups:    1,
+		notifyRemoved: notify,
 	}
 	defer l.Close()
 
@@ -366,9 +371,7 @@ func TestCleanupExistingBackups(t *testing.T) {
 	isNil(err, t)
 	equals(len(b2), n, t)
 
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(time.Millisecond * 10)
+	waitForNotify(notify, t)
 
 	// now we should only have 2 files left - the primary and one backup
 	fileCount(dir, 2, t)
@@ -382,12 +385,15 @@ func TestMaxAge(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	filename := logFile(dir)
+	notify := make(chan struct{})
 	l := &Logger{
-		Filename: filename,
-		MaxSize:  10,
-		MaxAge:   1,
+		Filename:      filename,
+		MaxSize:       10,
+		MaxAge:        1,
+		notifyRemoved: notify,
 	}
 	defer l.Close()
+
 	b := []byte("boo!")
 	n, err := l.Write(b)
 	isNil(err, t)
@@ -404,10 +410,6 @@ func TestMaxAge(t *testing.T) {
 	isNil(err, t)
 	equals(len(b2), n, t)
 	existsWithContent(backupFile(dir), b, t)
-
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(10 * time.Millisecond)
 
 	// We should still have 2 log files, since the most recent backup was just
 	// created.
@@ -427,9 +429,7 @@ func TestMaxAge(t *testing.T) {
 	equals(len(b3), n, t)
 	existsWithContent(backupFile(dir), b2, t)
 
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(10 * time.Millisecond)
+	waitForNotify(notify, t)
 
 	// We should have 2 log files - the main log file, and the most recent
 	// backup.  The earlier backup is past the cutoff and should be gone.
@@ -536,11 +536,12 @@ func TestRotate(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	filename := logFile(dir)
-
+	notify := make(chan struct{})
 	l := &Logger{
-		Filename:   filename,
-		MaxBackups: 1,
-		MaxSize:    100, // megabytes
+		Filename:      filename,
+		MaxBackups:    1,
+		MaxSize:       100, // megabytes
+		notifyRemoved: notify,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -556,10 +557,6 @@ func TestRotate(t *testing.T) {
 	err = l.Rotate()
 	isNil(err, t)
 
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(10 * time.Millisecond)
-
 	filename2 := backupFile(dir)
 	existsWithContent(filename2, b, t)
 	existsWithContent(filename, []byte{}, t)
@@ -569,9 +566,7 @@ func TestRotate(t *testing.T) {
 	err = l.Rotate()
 	isNil(err, t)
 
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(10 * time.Millisecond)
+	waitForNotify(notify, t)
 
 	filename3 := backupFile(dir)
 	existsWithContent(filename3, []byte{}, t)
@@ -594,11 +589,13 @@ func TestCompressOnRotate(t *testing.T) {
 	dir := makeTempDir("TestCompressOnRotate", t)
 	defer os.RemoveAll(dir)
 
+	notify := make(chan struct{})
 	filename := logFile(dir)
 	l := &Logger{
-		Compress: true,
-		Filename: filename,
-		MaxSize:  10,
+		Compress:         true,
+		Filename:         filename,
+		MaxSize:          10,
+		notifyCompressed: notify,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -618,9 +615,7 @@ func TestCompressOnRotate(t *testing.T) {
 	// nothing in it.
 	existsWithContent(filename, []byte{}, t)
 
-	// we need to wait a little bit since the files get compressed on a different
-	// goroutine.
-	<-time.After(300 * time.Millisecond)
+	waitForNotify(notify, t)
 
 	// a compressed version of the log file should now exist and the original
 	// should have been removed.
@@ -632,55 +627,6 @@ func TestCompressOnRotate(t *testing.T) {
 	isNil(err, t)
 	existsWithContent(backupFile(dir)+compressSuffix, bc.Bytes(), t)
 	notExist(backupFile(dir), t)
-
-	fileCount(dir, 2, t)
-}
-
-func TestCompressOnResume(t *testing.T) {
-	currentTime = fakeTime
-	megabyte = 1
-
-	dir := makeTempDir("TestCompressOnResume", t)
-	defer os.RemoveAll(dir)
-
-	filename := logFile(dir)
-	l := &Logger{
-		Compress: true,
-		Filename: filename,
-		MaxSize:  10,
-	}
-	defer l.Close()
-
-	// Create a backup file and empty "compressed" file.
-	filename2 := backupFile(dir)
-	b := []byte("foo!")
-	err := ioutil.WriteFile(filename2, b, 0644)
-	isNil(err, t)
-	err = ioutil.WriteFile(filename2+compressSuffix, []byte{}, 0644)
-	isNil(err, t)
-
-	newFakeTime()
-
-	b2 := []byte("boo!")
-	n, err := l.Write(b2)
-	isNil(err, t)
-	equals(len(b2), n, t)
-	existsWithContent(filename, b2, t)
-
-	// we need to wait a little bit since the files get compressed on a different
-	// goroutine.
-	<-time.After(300 * time.Millisecond)
-
-	// The write should have started the compression - a compressed version of
-	// the log file should now exist and the original should have been removed.
-	bc := new(bytes.Buffer)
-	gz := gzip.NewWriter(bc)
-	_, err = gz.Write(b)
-	isNil(err, t)
-	err = gz.Close()
-	isNil(err, t)
-	existsWithContent(filename2+compressSuffix, bc.Bytes(), t)
-	notExist(filename2, t)
 
 	fileCount(dir, 2, t)
 }
@@ -758,6 +704,8 @@ func fileCount(dir string, exp int, t testing.TB) {
 
 // newFakeTime sets the fake "current time" to two days later.
 func newFakeTime() {
+	fakeTimeMu.Lock()
+	defer fakeTimeMu.Unlock()
 	fakeCurrentTime = fakeCurrentTime.Add(time.Hour * 24 * 2)
 }
 
@@ -769,4 +717,14 @@ func notExist(path string, t testing.TB) {
 func exists(path string, t testing.TB) {
 	_, err := os.Stat(path)
 	assertUp(err == nil, t, 1, "expected file to exist, but got error from os.Stat: %v", err)
+}
+
+func waitForNotify(notify <-chan struct{}, t testing.TB) {
+	select {
+	case <-notify:
+		// All good.
+	case <-time.After(2 * time.Second):
+		fmt.Println("logger notify not signalled")
+		t.FailNow()
+	}
 }

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -773,11 +773,12 @@ func exists(path string, t testing.TB) {
 }
 
 func waitForNotify(notify <-chan struct{}, t testing.TB) {
+	t.Helper()
+
 	select {
 	case <-notify:
 		// All good.
 	case <-time.After(2 * time.Second):
-		fmt.Println("logger notify not signalled")
-		t.FailNow()
+		t.Fatal("logger notify not signalled")
 	}
 }


### PR DESCRIPTION
This is an attempt to upstream and complete the [patch](https://github.com/natefinch/lumberjack/pull/100) that @howbazaar started a couple of years ago.

The motivation for this patch is to move back to tracking upstream rather than an independent fork.

The original description and PR https://github.com/natefinch/lumberjack/pull/100:

> Currently the millRun goroutines leaks. This is very noticeable if
> a Logger is constructed periodically, used and then closed.
> This change ensures that the millCh channel is closed if it exists.
> Existing log rotation tests cover the duplicate Close calls.